### PR TITLE
EAN13 must be included only in variations if they exists

### DIFF
--- a/ebay/api/AddFixedPriceItem.tpl
+++ b/ebay/api/AddFixedPriceItem.tpl
@@ -76,6 +76,8 @@
 		{$return_policy}
 		{if isset($variations)}
 			{$variations}
+		{else if isset($product_listing_details)}
+            		{$product_listing_details}
 		{/if}
 		<ShippingDetails>{$shipping_details}</ShippingDetails>
 		{$buyer_requirements_details}


### PR DESCRIPTION
ebay refuses ean13 if the product has variations
